### PR TITLE
Revert "Turn unnamed lists into BSON arrays instead of objects."

### DIFF
--- a/src/api_bson.c
+++ b/src/api_bson.c
@@ -1758,22 +1758,25 @@ SEXP mongo_bson_buffer_append(SEXP buf, SEXP name, SEXP value) {
 SEXP mongo_bson_buffer_append_list(SEXP buf, SEXP name, SEXP value) {
     bson_buffer* _buf = _checkBuffer(buf);
     const char* _name = CHAR(STRING_ELT(name, 0));
-    int success;
+    int success = (bson_append_start_object(_buf, _name) == BSON_OK);
     int len = LENGTH(value);
     int i;
     SEXP names = getAttrib(value, R_NamesSymbol);
-    if (names != R_NilValue){
-        success = (bson_append_start_object(_buf, _name) == BSON_OK);
+    SEXP fname;
+    if (names != R_NilValue)
         for (i = 0; i < len && success; i++) {
-            success &= LOGICAL(mongo_bson_buffer_append(buf, STRING_ELT(names, i), VECTOR_ELT(value, i)))[0];
+            PROTECT(fname = allocVector(STRSXP, 1));
+            SET_STRING_ELT(fname, 0, STRING_ELT(names, i));
+            success &= LOGICAL(mongo_bson_buffer_append(buf, fname, VECTOR_ELT(value, i)))[0];
+            UNPROTECT(1);
         }
-    }
-    else {
-        success = (bson_append_start_array(_buf, _name) == BSON_OK);
+    else
         for (i = 0; i < len && success; i++) {
-            success &= LOGICAL(mongo_bson_buffer_append(buf, mkString(""), VECTOR_ELT(value, i)))[0];
+            PROTECT(fname = allocVector(STRSXP, 1));
+            SET_STRING_ELT(fname, 0, mkChar(numstr(i+1)));
+            success &= LOGICAL(mongo_bson_buffer_append(buf, fname, VECTOR_ELT(value, i)))[0];
+            UNPROTECT(1);
         }
-    }
     success &= (bson_append_finish_object(_buf) == BSON_OK);
     SEXP ret;
     PROTECT(ret = allocVector(LGLSXP, 1));


### PR DESCRIPTION
Reverts mongosoup/rmongodb#49

> ll <- jsonlite:::fromJSON('{"$group":{"_id":"$state", "totalPop":{"$sum":"$pop"}}}')
> 
> mongo.bson.from.list(ll)
> Error in mongo.bson.from.list(ll) : 
>   STRING_ELT() can only be applied to a 'character vector', not a 'char'

not working!
