### PR TITLE
removed coersion to numbers. This was really not a good idea.

### DIFF
--- a/R/bson_convert.R
+++ b/R/bson_convert.R
@@ -223,11 +223,7 @@ mongo.bson.from.df <- function(df){
   
   
   
-  # Convert any numbers saved as string to numeric adata
-  data_list <- lapply(data_list,function(x) { lapply(x,function(y) {
-    if ( suppressWarnings(!is.na(as.numeric(y))) & !is.integer(y) & !(class(y)[1]=="POSIXct") ) {as.numeric(y)}else{y}
-  })
-  })
+
   
   # Iterate over the table and create the BSON object
   bson_data <- lapply(data_list,function(x){


### PR DESCRIPTION
In the original mongo.bson.from.df I had included a step that coerced to numbers if possible. This is not a good idea. There are too many cases where this is not what you want and I cannot include exceptions for all of them.
