### PR TITLE
Update gridfs.h

### DIFF
--- a/src/libmongo/gridfs.h
+++ b/src/libmongo/gridfs.h
@@ -24,7 +24,7 @@
 #ifndef MONGO_GRIDFS_H_
 #define MONGO_GRIDFS_H_
 
-enum {DEFAULT_CHUNK_SIZE = 256 * 1024};
+enum {DEFAULT_CHUNK_SIZE = 255 * 1024};
 
 typedef uint64_t gridfs_offset;
 


### PR DESCRIPTION
gridfs interface: Reduce chunk size to 255k for compatibility with MongoDB >= 2.4.10
