### PR TITLE
Fix compilation errors for modern GCC compilers

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -15,6 +15,7 @@
 #include <R.h>
 #include <R_ext/Rdynload.h>
 #include <R_ext/Visibility.h>
+#include <stdlib.h>
 
 #include "api_bson.h"
 #include "api_mongo.h"
@@ -147,21 +148,21 @@ static const R_CallMethodDef callMethods[] = {
 
 
 static void* _malloc(size_t size) {
-    return (void*)Calloc(size, char);
+    return (void*)calloc(size, sizeof(char));
 }
 
 
 static void* _realloc(void* p, size_t size) {
-    return (void*)Realloc(p, size, char);
+    return (void*)realloc(p, size * sizeof(char));
 }
 
 
 static void _free(void* p) {
-    Free(p);
+    free(p);
 }
 
 static void _err_handler(const char* errmsg) {
-    error(errmsg);
+    error("%s", errmsg);
 }
 
 

--- a/src/api_bson.c
+++ b/src/api_bson.c
@@ -208,7 +208,7 @@ static void bson_bufferFinalizer(SEXP ptr) {
     if (!R_ExternalPtrAddr(ptr)) return;
     bson_buffer* b = (bson_buffer*)R_ExternalPtrAddr(ptr);
     bson_destroy_old(b);
-    Free(b);
+    free(b);
     R_ClearExternalPtr(ptr);
 }
 
@@ -217,7 +217,7 @@ SEXP _mongo_bson_buffer_create() {
     SEXP ret, ptr, cls;
     PROTECT(ret = allocVector(INTSXP, 1));
     INTEGER(ret)[0] = 0;
-    bson_buffer* buf = Calloc(1, bson_buffer);
+    bson_buffer* buf = (bson_buffer*)calloc(1, sizeof(bson_buffer));
     bson_init_old(buf);
     ptr = R_MakeExternalPtr(buf, sym_mongo_bson_buffer, R_NilValue);
     PROTECT(ptr);
@@ -240,7 +240,7 @@ SEXP mongo_bson_buffer_create() {
 static void bson_OIDfinalizer(SEXP ptr) {
     if (!R_ExternalPtrAddr(ptr)) return;
     bson_oid_t* oid = (bson_oid_t*)R_ExternalPtrAddr(ptr);
-    Free(oid);
+    free(oid);
     R_ClearExternalPtr(ptr); /* not really needed */
 }
 
@@ -260,7 +260,7 @@ SEXP _mongo_oid_create(bson_oid_t* oid) {
 
 
 SEXP mongo_oid_create() {
-    bson_oid_t* oid = Calloc(1, bson_oid_t);
+    bson_oid_t* oid = (bson_oid_t*)calloc(1, sizeof(bson_oid_t));
     bson_oid_gen(oid);
     SEXP ret = _mongo_oid_create(oid);
     UNPROTECT(3);
@@ -299,7 +299,7 @@ SEXP mongo_bson_print(SEXP b) {
 static void bsonIteratorFinalizer(SEXP ptr) {
     if (!R_ExternalPtrAddr(ptr)) return;
     bson_iterator* iter = (bson_iterator*)R_ExternalPtrAddr(ptr);
-    Free(iter);
+    free(iter);
     R_ClearExternalPtr(ptr); /* not really needed */
 }
 
@@ -308,7 +308,7 @@ SEXP _mongo_bson_iterator_create(bson_iterator* iter) {
     SEXP ret, ptr, cls;
     PROTECT(ret = allocVector(INTSXP, 1));
     INTEGER(ret)[0] = 0;
-    bson_iterator* _iter = Calloc(1, bson_iterator);
+    bson_iterator* _iter = (bson_iterator*)calloc(1, sizeof(bson_iterator));
     memcpy(_iter, iter, sizeof(bson_iterator));
     PROTECT(ptr = R_MakeExternalPtr(_iter, sym_mongo_bson_iterator, R_NilValue));
     R_RegisterCFinalizerEx(ptr, bsonIteratorFinalizer, TRUE);
@@ -452,7 +452,7 @@ SEXP _array_to_object(bson_iterator* iter) {
     do {
         bson_iterator_subiterator(&sub[dims], &sub[dims+1]);
         if (++dims > MAXDIM)
-            error("Max dimensions (%d) exceeded. Use an iterator\n");
+            error("Max dimensions (%d) exceeded. Use an iterator\n", MAXDIM);
         sub_type = bson_iterator_next(&sub[dims]);
     }
     while (sub_type == BSON_ARRAY);
@@ -691,7 +691,7 @@ SEXP _mongo_bson_value(bson_iterator* _iter) {
         return R_NilValue;
 
     case BSON_OID: {
-        bson_oid_t* oid = Calloc(1, bson_oid_t);
+        bson_oid_t* oid = (bson_oid_t*)calloc(1, sizeof(bson_oid_t));
         memcpy(oid, bson_iterator_oid(_iter), sizeof(bson_oid_t));
         ret = _mongo_oid_create(oid);
         UNPROTECT(3);
@@ -981,7 +981,7 @@ SEXP mongo_oid_from_string(SEXP hexstr) {
     const char* _hexstr = CHAR(STRING_ELT(hexstr, 0));
     if (strlen(_hexstr) != 24)
         error("OID string length must be 24");
-    bson_oid_t* oid = Calloc(1, bson_oid_t);
+    bson_oid_t* oid = (bson_oid_t*)calloc(1, sizeof(bson_oid_t));
     bson_oid_from_string(oid, _hexstr);
     SEXP ret = _mongo_oid_create(oid);
     UNPROTECT(3);

--- a/src/api_gridfs.c
+++ b/src/api_gridfs.c
@@ -52,9 +52,9 @@ SEXP mongo_gridfs_create(SEXP mongo_conn, SEXP db, SEXP prefix) {
     mongo* conn = _checkMongo(mongo_conn);
     const char* _db = CHAR(STRING_ELT(db, 0));
     const char* _prefix = CHAR(STRING_ELT(prefix, 0));
-    gridfs* gfs = Calloc(1, gridfs);
+    gridfs* gfs = (gridfs*)calloc(1, sizeof(gridfs));
     if (gridfs_init(conn, _db, _prefix, gfs) != MONGO_OK) {
-        Free(gfs);
+        free(gfs);
         return R_NilValue;
     }
     SEXP ret, ptr, cls;
@@ -132,7 +132,7 @@ SEXP mongo_gridfile_writer_create(SEXP gfs, SEXP remotename, SEXP contenttype) {
     gridfs* _gfs = _checkGridfs(gfs);
     const char* _remotename = CHAR(STRING_ELT(remotename, 0));
     const char* _contenttype = CHAR(STRING_ELT(contenttype, 0));
-    gridfile* gfile = Calloc(1, gridfile);
+    gridfile* gfile = (gridfile*)calloc(1, sizeof(gridfile));
 
     SEXP ret, ptr, cls;
     PROTECT(ret = allocVector(INTSXP, 1));
@@ -176,7 +176,7 @@ SEXP mongo_gridfile_writer_finish(SEXP gfw) {
     SEXP ret;
     PROTECT(ret = allocVector(LGLSXP, 1));
     LOGICAL(ret)[0] = (gridfile_writer_done(gfile) == MONGO_OK);
-    Free(gfile);
+    free(gfile);
     R_ClearExternalPtr(getAttrib(gfw, sym_mongo_gridfile));
     UNPROTECT(1);
     return ret;
@@ -206,7 +206,7 @@ SEXP mongo_gridfile_destroy(SEXP gfile) {
 
 SEXP mongo_gridfs_find(SEXP gfs, SEXP query) {
     gridfs* _gfs = _checkGridfs(gfs);
-    gridfile* gfile = Calloc(1, gridfile);
+    gridfile* gfile = (gridfile*)calloc(1, sizeof(gridfile));
     int result;
     if (_isBSON(query)) {
         bson* _query = _checkBSON(query);

--- a/src/api_mongo.c
+++ b/src/api_mongo.c
@@ -40,7 +40,7 @@ SEXP mmongo_create() {
     SEXP ret, ptr, cls;
     PROTECT(ret = allocVector(INTSXP, 1));
     INTEGER(ret)[0] = 0;
-    mongo* conn = Calloc(1, mongo);
+    mongo* conn = (mongo*)calloc(1, sizeof(mongo));
     ptr = R_MakeExternalPtr(conn, sym_mongo, R_NilValue);
     PROTECT(ptr);
     R_RegisterCFinalizerEx(ptr, mongoFinalizer, TRUE);
@@ -190,7 +190,7 @@ SEXP rmongo_insert_batch(SEXP mongo_conn, SEXP ns, SEXP b) {
     if (TYPEOF(b) != VECSXP)
         error("Expected a list of mongo.bson class objects");
     int len = LENGTH(b);
-    bson** blist = Calloc(len, bson*);
+    bson** blist = (bson**)calloc(len, sizeof(bson*));
     int i;
     int success = 1;
     for (i = 0; i < len && success; i++) {
@@ -202,7 +202,7 @@ SEXP rmongo_insert_batch(SEXP mongo_conn, SEXP ns, SEXP b) {
     }
     if (success)
         LOGICAL(ret)[0] = (mongo_insert_batch(conn, _ns, (const bson**)blist, len, 0, 0) == MONGO_OK);
-    Free(blist);
+    free(blist);
     if (!success)
         error("Expected list of mongo.bson class objects");
     UNPROTECT(1);
@@ -304,7 +304,7 @@ SEXP rmongo_find(SEXP mongo_conn, SEXP ns, SEXP query, SEXP sort, SEXP fields, S
       strcpy(str, _ns);
       char* _db = strtok(str, ".");
       if (mongo_cmd_get_last_error(conn, _db, &out) != MONGO_OK) {
-        error(conn->lasterrstr);
+        error("%s", conn->lasterrstr);
       }
       error("find failed with unknown error.");
     }
@@ -391,14 +391,14 @@ SEXP rmongo_count(SEXP mongo_conn, SEXP ns, SEXP query) {
     if (!p)
         error("Expected a '.' in the namespace.");
     int len = p - (char*)_ns;
-    char* db = Calloc(len+1, char);
+    char* db = (char*)calloc(len+1, sizeof(char));
     strncpy(db, _ns, len);
     db[len] = '\0';
     bson* _query = _checkBSON(query);
     SEXP ret;
     PROTECT(ret = allocVector(REALSXP, 1));
     REAL(ret)[0] = mongo_count(conn, db, p+1, _query);
-    Free(db);
+    free(db);
     UNPROTECT(1);
     return ret;
 }
@@ -458,13 +458,13 @@ SEXP mongo_drop(SEXP mongo_conn, SEXP ns) {
     if (!p)
         error("Expected a '.' in the namespace.");
     int len = p - (char*)_ns;
-    char* db = Calloc(len+1, char);
+    char* db = (char*)calloc(len+1, sizeof(char));
     strncpy(db, _ns, len);
     db[len] = '\0';
     SEXP ret;
     PROTECT(ret = allocVector(LGLSXP, 1));
     LOGICAL(ret)[0] = (mongo_cmd_drop_collection(conn, db, p+1, NULL) == MONGO_OK);
-    Free(db);
+    free(db);
     UNPROTECT(1);
     return ret;
 }

--- a/src/utility.c
+++ b/src/utility.c
@@ -88,7 +88,7 @@ static void bsonFinalizer(SEXP ptr) {
     if (!R_ExternalPtrAddr(ptr)) return;
     bson* b = (bson*)R_ExternalPtrAddr(ptr);
     bson_destroy_old(b);
-    Free(b);
+    free(b);
     R_ClearExternalPtr(ptr); /* not really needed */
 }
 
@@ -97,7 +97,7 @@ SEXP _mongo_bson_create(bson* b) {
     SEXP ret, ptr, cls;
     PROTECT(ret = allocVector(INTSXP, 1));
     INTEGER(ret)[0] = 0;
-    bson* obj = Calloc(1, bson);
+    bson* obj = (bson*)calloc(1, sizeof(bson));
     bson_copy_old(obj, b);
     ptr = R_MakeExternalPtr(obj, sym_mongo_bson, R_NilValue);
     PROTECT(ptr);


### PR DESCRIPTION
Fixed compilation errors that prevented building with modern GCC versions due to deprecated R memory allocation macros and format-security warnings.

Changes:
- Replaced R's Calloc/Realloc/Free macros with standard C calloc/realloc/free
- Fixed format-security errors in error() calls by adding format specifiers
- Added stdlib.h include for standard C memory functions

Fixed in the following files:
- src/api.c: Memory allocation helpers and error handler
- src/api_bson.c: Multiple Calloc/Free calls and MAXDIM error format
- src/api_mongo.c: Calloc/Free calls and connection error format
- src/api_gridfs.c: GridFS memory allocation calls
- src/utility.c: BSON object allocation

Package now compiles successfully with GCC 13.3.0 and -Werror=format-security.
